### PR TITLE
Fixed parsing of superclass and typechecking of inherited member fields

### DIFF
--- a/compiler.ts
+++ b/compiler.ts
@@ -79,65 +79,6 @@ export function compile(ast: Program<Type>, env: GlobalEnv) : CompileResult {
   };
 }
 
-/*
-the way this https://ucsd-cse231-w21.github.io/objects/ explains it
-if we want to call l.sum()
-then we first need to have the address of l on the stack (the reference)
-i think in class we said the object itself would have the offset in it or something
-which is why they do the first (i32.load)
-but perhapents we can store that info globally instead of per object
-
-<stack has all the args + self on there>
-(i32.load) <-- we want to load the offset from the object data itself
-(i32.add <method offset -- this one is not a bytes thing so no *4>)
-(i32.load <address of l>) --> for self argument
-(call_indirect (type $return_i32))
-
-ok so ast -> ir loses the method-call distinction
-it gets turned into
-return [
-        [...objinits, ...arginits],
-        [...objstmts, checkObj, ...argstmts],
-        callMethod
-      ]
-which is really confusing to me
-i guess what i should do is figure out what a method call codegen looks like at base
-
-...
-func(x)
--->
-(global.get $x)
-(call $func)
-
-...
-a = A()
-a.f(x, y)
--->
-constructor + assign
-  call $alloc
-  (global.set $newObj1)
-  (global.get $newObj1)
-  (call $A$__init__)
-  (local.set $$last)
-  (global.get $newObj1)
-  (global.set $a)
----
-method call
-  (global.get $a)
-  (call $assert_not_none)
-  (local.set $$last)
-  (global.get $a)
-  (global.get $x)
-  (global.get $y)
-  (call $A$f)
-basically we need to replace the call w/ a call_indirect
-direct call is only for functions
-
-*/
-// function codeGenVTable(ast: Program<Type>, env: GlobalEnv): Array<string> {
-  
-// }
-
 function codeGenStmt(stmt: Stmt<Type>, env: GlobalEnv): Array<string> {
   switch (stmt.tag) {
     case "store":

--- a/compiler.ts
+++ b/compiler.ts
@@ -177,11 +177,11 @@ function codeGenExpr(expr: Expr<Type>, env: GlobalEnv): Array<string> {
       valStmts.push(`(call $${expr.name})`);
       return valStmts;
     
-    case "method_call":
-      // we have expr.classname
-      return [
+    // case "method_call":
+    //   // we have expr.classname
+    //   return [
 
-      ];
+    //   ];
     case "alloc":
       return [
         ...codeGenValue(expr.amount, env),

--- a/designs/inheritance-design.md
+++ b/designs/inheritance-design.md
@@ -267,3 +267,18 @@ We think the resulting table should look something like
 We would put ```A$foo``` in twice and note A's offset as 0 while B's offset is 1.
 This way, if something like ```B().foo(0)``` is called, then the WASM will know to reference the ```A$foo``` at offset 1.
 
+## new test:
+```
+class A(object):
+    a : int = 1
+class B(A):
+    b : int = 1
+class C(B):
+    c : bool = False
+x : C = None
+x = C()
+print(x.a)
+print(x.b)
+print(x.c)
+```
+We expect that C inherits 2 fields for a total of 3.

--- a/parser.ts
+++ b/parser.ts
@@ -433,7 +433,6 @@ export function traverseClass(c : TreeCursor, s : string) : Class<null> {
   }
   var supers : Array<string> = [];
   c.firstChild();
-  console.log("traversed supers",superExpr);
   superExpr.forEach((e)=>{
     if(e.tag === "id") {
       if(e.name !== "object"){

--- a/parser.ts
+++ b/parser.ts
@@ -431,16 +431,14 @@ export function traverseClass(c : TreeCursor, s : string) : Class<null> {
   if (superExpr.length == 0) {
     throw new Error(`Class must have at least one super class: ${className}`);
   }
-  var supers:Array<string> = [];
+  var supers : Array<string> = [];
   c.firstChild();
-  
+  console.log("traversed supers",superExpr);
   superExpr.forEach((e)=>{
-    c.nextSibling();
-    if(e.tag==="id"){
-      if(e.name!=="object"){
+    if(e.tag === "id") {
+      if(e.name !== "object"){
         supers.push(e.name);
       }
-      
     } else {
       throw new Error(`Parse Error near token ${s.substring(c.from, c.to)}`);
     }

--- a/runner.ts
+++ b/runner.ts
@@ -56,6 +56,7 @@ export function augmentEnv(env: GlobalEnv, prog: Program<Type>) : GlobalEnv {
     cls.fields.forEach((field, i) => classFields.set(field.name, [i, field.value]));
     newClasses.set(cls.name, classFields);
   });
+  
   return {
     globals: newGlobals,
     classes: newClasses,

--- a/runner.ts
+++ b/runner.ts
@@ -72,6 +72,7 @@ export async function run(source : string, config: Config) : Promise<[Value, Glo
   const [tprogram, tenv] = tc(config.typeEnv, parsed);
   const globalEnv = augmentEnv(config.env, tprogram);
   const irprogram = lowerProgram(tprogram, globalEnv);
+  console.log("irprogram:", irprogram);
   const progTyp = tprogram.a;
   var returnType = "";
   var returnExpr = "";

--- a/runner.ts
+++ b/runner.ts
@@ -123,7 +123,7 @@ export async function run(source : string, config: Config) : Promise<[Value, Glo
       ${returnExpr}
     )
   )`;
-  console.log(wasmSource);
+  // console.log(wasmSource); -- commented out bc my console output was getting cut off, and i need to fix the typechecker
   const [result, instance] = await runWat(wasmSource, importObject);
 
   return [PyValue(progTyp, result), compiled.newEnv, tenv, compiled.functions, instance];

--- a/type-check.ts
+++ b/type-check.ts
@@ -249,21 +249,10 @@ export function tcClass(env: GlobalTypeEnv, cls : Class<null>) : Class<Type> {
   });
   cls.supers.forEach(sup => {
     const superclassdef = classMap.get(sup);
-    const supFields = env.classes.get(sup)[1];
-    supFields.forEach((fieldType, fieldName) => { // foreach on map runs on (value, key) order
-      if(!allFields.has(fieldName)) {
-        allFields.set(fieldName, fieldType); // update the environment w/ the inherited field
-        superclassdef.fields.forEach(fielddef => { // this is extremely ugly O(n) bc our global env doesn't store varinits, only field name + type
-          if (fielddef.name === fieldName) {
-            console.log(`${cls.name} is inheriting ${fielddef.name} from ${sup}`);
-            tFieldDefs.push(fielddef); // update this AST class struct w/ the inherited field def
-          } else {
-            console.log(fielddef.name);
-          }
-        });
-      } else {
-        throw new TypeCheckError("this should never happen");
-      }
+    superclassdef.fields.forEach(fielddef => { // this is extremely ugly O(n) bc our global env doesn't store varinits, only field name + type
+      console.log(`${cls.name} is inheriting ${fielddef.name} from ${sup}`);
+        tFieldDefs.push(fielddef); // update this AST class struct w/ the inherited field def
+        allFields.set(fielddef.name, fielddef.type);
     });
   });
  

--- a/type-check.ts
+++ b/type-check.ts
@@ -226,28 +226,26 @@ export function tcClass(env: GlobalTypeEnv, cls : Class<null>) : Class<Type> {
   // GlobalEnv
   const tFields = cls.fields.map(field => tcInit(env, field));
   // Check whether fields overlap between super and sub class
+
+  //
+  const curFields = env.classes.get(cls.name)[1];
   cls.fields.forEach(field => {
     cls.supers.forEach(sup => {
       const supFields = env.classes.get(sup)[1];
       if(supFields.has(field.name)) {
         throw new TypeCheckError(`Cannot re-define attribute ${field.name}`);
       }
-      //const supClass = classMap.get(sup);
-
+      const supClass = classMap.get(sup);
+      supClass.fields.forEach((b)=>{
+        var fieldName = b.name;
+        if(!curFields.has(fieldName)){
+          tFields.unshift(b);
+          curFields.set(b.name,b.type);
+        }
+      })
     });
   });
-  // A(B,C)
-  // B->a:int 
-  // C-> a:int
-
-  // Push super class fields to derived class env
-  const curFields = env.classes.get(cls.name)[1];
-  cls.supers.forEach(sup => {
-    const supFields = env.classes.get(sup)[1];
-    supFields.forEach( (type, name) => {
-      curFields.set(name, type);
-    });
-  });
+ 
   
   const tMethods = cls.methods.map(method => tcDef(env, method));
   

--- a/type-check.ts
+++ b/type-check.ts
@@ -256,7 +256,16 @@ export function tcClass(env: GlobalTypeEnv, cls : Class<null>) : Class<Type> {
     });
   });
  
-  
+  /*
+  this is currently wrong:
+  running tcDef here on this class's methods before we populate it with all the inherited stuff
+  means tcDef will fail if we call an inherited method e.g. self.inherited()
+  therefore, a better unified pattern is to populate this class's global state w/ all the inherited members and methods, since we know they're all typechecked and safe
+  and then typecheck this class's members and methods
+  when updating global state, if this class attempts to redefine a member, then we error out
+  if this class attempts to redefine a method, then we allow with caveats I think
+  */
+
   const tMethods = cls.methods.map(method => tcDef(env, method));
   
   // To check if we have method overwritten with different signature in the derived class


### PR DESCRIPTION
Parser:
The code had a nextSibling() call that seemed to be breaking things.
Now, the superclass should be parsed properly.

Typechecker:
We were not handling chained inheritance correctly.
I believe I have fixed it for member fields. TODO for methods, but it should be similar.
Essentially, we seem to expect
1) inheritance happens in order, like a subclass can't be defined before the superclass
2) when we typecheck, we populate global state as we go. but we don't do any recursive checking, so we must expect that a superclass contains all inherited fields and methods. this is not the case currently because classMap doesn't get updated. I fixed this and did some minor cleanup + commenting.
I am worried about our design though, since we maintain so much global stuff outside of the GlobalEnv.